### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action:authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:show]
   def index
     @items = Item.order(id: 'DESC')
   end
@@ -15,11 +16,18 @@ class ItemsController < ApplicationController
     else
       render action: :new
   end
+
+  def show
+  end
 end
 
 private
 
 def item_params
   params.require(:item).permit(:image, :title, :text, :category_id, :condition_id, :postage_payer_id, :prefecture_id, :preparation_day_id, :price).merge(user_id: current_user.id)
+end
+
+def set_item
+  @item = Item.find(params[:id])
 end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
@@ -144,7 +144,9 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.postage_payer.name %></span>
+            <span><%= item.price %>円
+            <br><%= item.postage_payer.name %>
+            </span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,13 +131,11 @@
         <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if item.order != nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
+          <% end %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,68 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        (税込) 送料込み
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && current_user.id == @item.user_id && @item.order == nil %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%= link_to '購入画面に進む', item_orders_path(@item) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.postage.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.preparation_day %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% if @item.order != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -30,12 +28,9 @@
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% elsif user_signed_in? && @item.order == nil %>
     <%= link_to '購入画面に進む', item_orders_path(@item) ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
@@ -45,7 +40,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td>
+          <td class="detail-value"><%= @item.user.nick_name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
@@ -57,7 +52,7 @@
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.postage.name %></td>
+          <td class="detail-value"><%= @item.postage_payer.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
@@ -65,7 +60,7 @@
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.preparation_day %></td>
+          <td class="detail-value"><%= @item.preparation_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]do
+  resources :items, only: [:index, :new, :create, :show]do
     resources :orders, only: [:index, :create]
   end
 end


### PR DESCRIPTION
#What
商品詳細表示機能の実装
#Why
商品詳細ページを表示する為

ログイン状態の出品者のみ、「編集・削除ボタン」が表示される
https://gyazo.com/8c936969a01e9671c90ce0a75b675385
ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されない
https://gyazo.com/a7d8645d8ba09f76d06aef28941a7581
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
https://gyazo.com/de6add5d2ad8a48b9a205bc96f115cda
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる＆ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
https://gyazo.com/76f242ef64da2a63eb2a6044d3e28567
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっている
https://gyazo.com/dce899e7eff53110657cdf4c2e6ed2e5